### PR TITLE
fix: use separate autolabeler action for release-drafter v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,33 +2,31 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
   # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  update_release_draft:
+  autolabeler:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+  update_release_draft:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
       - uses: release-drafter/release-drafter@v7
         with:
           publish: true
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- release-drafter v7ではdrafterとautolabelerが別アクションに分離された
- PR時: `release-drafter/release-drafter/autolabeler@v7` でラベル付与のみ
- push時: `release-drafter/release-drafter@v7` でリリース作成のみ
- `permissions` を明示的に設定

## Test plan
- [ ] PRイベントでautolabelerジョブが成功すること
- [ ] mainへのpush時にリリースが正しく作成されること