### PR TITLE
Renovate の auto-merge 設定を追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,43 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "automergeStrategy": "merge-commit",
+  "packageRules": [
+    {
+      "description": "開発・テスト用 gem の minor/patch は automerge",
+      "matchManagers": [
+        "bundler"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "matchPackageNames": [
+        "/^rubocop/",
+        "/^rspec/",
+        "/^ostruct$/"
+      ]
+    },
+    {
+      "description": "信頼できる GitHub Actions の minor/patch/digest は automerge",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "matchPackageNames": [
+        "actions/checkout",
+        "release-drafter/release-drafter",
+        "ruby/setup-ruby"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## 概要

`renovate.json` が `config:recommended` のみで auto-merge が設定されておらず、依存更新 PR がすべて手動マージ待ちになっています。kaki-org/baukis2・kaki-org/taskleaf と同じ許可リスト方式で auto-merge を設定します。

## 変更内容

### `renovate.json`
- 開発・テスト用 gem（`rubocop*` / `rspec*` / `ostruct`）の `minor` / `patch` 更新を automerge
- 本リポジトリで実際に使用している GitHub Actions の `minor` / `patch` / `digest` 更新を automerge
- `automergeStrategy: merge-commit` を指定（本リポジトリは squash / rebase が無効なため）

本リポジトリの Gemfile は `ostruct` / `rspec` / `rubocop` / `rubocop-rspec` のみで、いずれも RSpec で検証される開発用途の gem です。

## 前提: branch protection

auto-merge は「マージ可能になった時点で自動マージ」する機能のため、required status checks が無いと CI 完了を待たずに即マージされます。そのため本 PR とは別に、`main` ブランチへ以下を設定済みです。

- required status checks: `rspec_job`（`.github/workflows/ruby.yml`）
- strict（base への追従必須）は無効
- required approving reviews は 0 件（レビュー必須にすると auto-merge が永久に待機するため）

## 補足

Dependabot は本リポジトリでは未設定のため、Dependabot 用の auto-merge ワークフローは追加していません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling.
  * Minor and patch updates for selected development dependencies and trusted workflow actions can now be merged automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->